### PR TITLE
add fix for for multi-language setups.

### DIFF
--- a/config/hooks.php
+++ b/config/hooks.php
@@ -21,7 +21,7 @@ return [
 
 		// process form submission
 		if ( get('commentions') && get('submit') )
-			Commentions::queueComment( $path );
+			Commentions::queueComment( $route->arguments()[0] );
 
 	}
 


### PR DESCRIPTION
Hey @sebastiangreger, thank you for creating this plugin!
It is very useful and and I'm using it in one of my projetcts.

I noticed an issue when trying to add a new comment on a multi-language kirby site:

`$path` also includes the language prefix (like `/en/articles/my-post`).
this prevents `page()` from finding the page, resulting in an error

using `$route->arguments()[0]` instead seems to work.