### PR TITLE
Move name and source formatting to methods.

### DIFF
--- a/languages/de.php
+++ b/languages/de.php
@@ -1,6 +1,11 @@
 <?php
 
 return [
+    // general
+
+    'commentions.name.anonymous'                    => 'Anonym',
+
+
     // snippets
 
     // - form
@@ -16,12 +21,12 @@ return [
 
     // - list
     'commentions.snippet.list.comments'             => 'Kommentare',
-    'commentions.snippet.list.anonymous'            => 'Anonym',
-    'commentions.snippet.list.mentioned'            => 'erwähnte dies',
-    'commentions.snippet.list.mentionedAt'          => 'erwähnte dies auf { link }',
-    'commentions.snippet.list.liked'                => 'gab diesem Beitrag ein „Gefällt mir« auf { link }',
-    'commentions.snippet.list.bookmarked'           => 'fügte ein Lesezeichen hinzu auf { link }',
-    'commentions.snippet.list.replies'              => 'antwortete auf { link }',
+    'commentions.snippet.list.comment'              => '{ author }',
+    'commentions.snippet.list.mentioned'            => '{ author } erwähnte dies',
+    'commentions.snippet.list.mentionedAt'          => '{ author } erwähnte dies auf { link }',
+    'commentions.snippet.list.liked'                => '{ author } gab diesem Beitrag ein „Gefällt mir« auf { link }',
+    'commentions.snippet.list.bookmarked'           => '{ author } fügte ein Lesezeichen hinzu auf { link }',
+    'commentions.snippet.list.replies'              => '{ author } antwortete auf { link }',
     'commentsions.snippet.list.dateFormat.date'     => 'd.m.Y H:i Uhr',
     'commentsions.snippet.list.dateFormat.strftime' => '%d.%m.%Y %H:%M Uhr',
 

--- a/languages/en.php
+++ b/languages/en.php
@@ -1,6 +1,11 @@
 <?php
 
 return [
+    // general
+
+    'commentions.name.anonymous'                    => 'Anonymous',
+
+
     // snippets
 
     // - form
@@ -16,12 +21,12 @@ return [
 
     // - list
     'commentions.snippet.list.comments'             => 'Comments',
-    'commentions.snippet.list.anonymous'            => 'Anonymous',
-    'commentions.snippet.list.mentioned'            => 'mentioned this',
-    'commentions.snippet.list.mentionedAt'          => 'mentioned this at { link }',
-    'commentions.snippet.list.liked'                => 'liked this at { link }',
-    'commentions.snippet.list.bookmarked'           => 'bookmarked this at { link }',
-    'commentions.snippet.list.replies'              => 'replied at { link }',
+    'commentions.snippet.list.comment'              => '{ author }',
+    'commentions.snippet.list.mentioned'            => '{ author } mentioned this',
+    'commentions.snippet.list.mentionedAt'          => '{ author } mentioned this at { link }',
+    'commentions.snippet.list.liked'                => '{ author } liked this at { link }',
+    'commentions.snippet.list.bookmarked'           => '{ author } bookmarked this at { link }',
+    'commentions.snippet.list.replies'              => '{ author } replied at { link }',
     'commentsions.snippet.list.dateFormat.date'     => 'Y-m-d H:i',
     'commentsions.snippet.list.dateFormat.strftime' => '%Y-%m-%d %H:%M',
 

--- a/sections/commentions.php
+++ b/sections/commentions.php
@@ -78,7 +78,7 @@ return [
             // transpose all comments into an array
             foreach ($comments as $data) {
                 $text = isset($data['text']) ? htmlspecialchars($data['text']) : '';
-                $name = isset($data['name']) ? htmlspecialchars($data['name']) : '';
+                $name = isset($data['name']) ? htmlspecialchars($data['name']) : t('commentions.name.anonymous');
                 $meta = $data['type'];
 
                 // avoid returning empty array entries when no commentions exist

--- a/snippets/commentions-list.php
+++ b/snippets/commentions-list.php
@@ -22,12 +22,6 @@
 
         <li class="commentions-list-item commentions-list-item-<?= $comment->type() ?><?= r($comment->isAuthenticated(), ' commentions-list-item-authenticated') ?>">
           <h4>
-            <?php if ($comment->website()->isNotEmpty()): ?>
-              <a href="<?= $comment->website() ?>" rel="noopener"><?= $comment->name()->html() ?></a>
-            <?php else: ?>
-              <?= $comment->name()->html() ?>
-            <?php endif ?>
-
             <?= $comment->sourceFormatted() ?>
           </h4>
 


### PR DESCRIPTION
Added `sourceFormatted()` and `nameFormatted()` methods and updated translations file.

`sourceFormatted(?string $anonymous = null)`: Formats the whole source including author and author link, if website is given.
`nameFormatted(?string $anonymous = null)`: Returns the HTML-escaped version of the name or `$anoynymous` as fallback, if given. If `$anoynymous` is not set, it will return the default value of *Anonymous*, as defined in the language files.

I also added a

```
'commentions.snippet.list.comment' => '{ author }',
```

translation, if some language requires additional formatting or someone wants to override the translation with something like `{ author } wrote this comment:`.