### PR TITLE
41 cronjob updates

### DIFF
--- a/classes/Commentions.php
+++ b/classes/Commentions.php
@@ -107,7 +107,9 @@ class Commentions
      *
      * @param \Kirby\Cms\Page $page The parent page object
      * @param string $uid The UID of the comment to be updated
-     * @param array $data The fields to be updated in the comment data
+     * @param array|string $data Depending on the action to be carried out:
+     *                           - Array: The fields of the entry that are to be replaced
+     *                           - String: A predefined action (currently only valid: 'delete', to delete the complete entry)
      * @return array $data The data that has been sent to the Storage class
      */
     public static function update($page, $uid, $data)

--- a/classes/Commentions.php
+++ b/classes/Commentions.php
@@ -119,6 +119,9 @@ class Commentions
             unset($data['uid']);
         }
 
+        // sanitize data array, but keep the uid
+        $data = Commentions::sanitize($data, true);
+
         // trigger a hook that would allow to stop processing by throwing an exception
         kirby()->trigger('commentions.add:before', $page, $data);
 

--- a/classes/Cron.php
+++ b/classes/Cron.php
@@ -73,9 +73,9 @@ class Cron
             foreach (Storage::read($page, 'webmentionqueue') as $queueitem) {
 
                 // skip requests already marked as failed or source-target pairs pinged during this cron run
-                if (!isset($queueitem['failed']) && !in_array($source . $target, $processedpairs)) {
+                if (!isset($queueitem['failed']) && !in_array($queueitem['source'] . $queueitem['target'], $processedpairs)) {
 
-                    // create/update the lockfile, as this is where actual DoS harm can be done
+                    // create/update the lockfile
                     F::write($lockfile, '');
 
                     // ensure that the same domain is pinged max. every n seconds
@@ -115,7 +115,7 @@ class Cron
                     }
 
                     // add the source-target pair to eliminate duplicates during this run
-                    $processedpairs[] = $source . $target;
+                    $processedpairs[] = $queueitem['source'] . $queueitem['target'];
                 }
             }
         }

--- a/classes/Cron.php
+++ b/classes/Cron.php
@@ -150,10 +150,9 @@ class Cron
             return 'Could not resolve target URL to Kirby page';
         }
 
-        // retrieve the source
-        $source = $request['source'];
-        // TODO: follow a limited amount of redirects
-        $remote = Remote::get($source);
+        // retrieve the source and use the final URL (after possible redirects) for processing
+        $remote = Remote::get($request['source']);
+        $source = $remote->info()['url'];
 
         // HTTP 410 = deletion
         if ($remote->info()['http_code'] === 410 && $page->commentions('all')->filterBy('source', $source)->count() != 0) {

--- a/classes/Cron.php
+++ b/classes/Cron.php
@@ -286,25 +286,19 @@ class Cron
 
             // create the commention data
             $finaldata = [
-                'name' => $result['author']['name'] ?? false,
-                'website' => $result['author']['url'] ?? false,
-                'avatar' => $result['author']['photo'] ?? false,
-                'text' => $result['text'],
-                'source' => $source,
-                'type' => $result['type'],
-                'language' => Commentions::determineLanguage($page, $path),
+                'name'      => $result['author']['name'] ?? false,
+                'website'   => $result['author']['url'] ?? false,
+                'avatar'    => $result['author']['photo'] ?? false,
+                'text'      => $result['text'],
+                'source'    => $source,
+                'type'      => $result['type'],
+                'language'  => Commentions::determineLanguage($page, $path),
+                'timestamp' => date('Y-m-d H:i', $result['timestamp']),
+                'status'    => Commentions::defaultstatus($result['type']),
             ];
 
-            if ($page->commentions('all')->filterBy('source', $source)->count() != 0) {
-                // if webmention with this source url exists, this is an update
-                $updateid = $page->commentions('all')->filterBy('source', $source)->first()->uid()->toString();
-                return Commentions::update($page, $updateid, $finaldata);
-            } else {
-                // add as new webmention
-                $finaldata['timestamp'] = date('Y-m-d H:i', $result['timestamp']);
-                $finaldata['status'] = Commentions::defaultstatus($result['type']);
-                return Commentions::add($page, $finaldata);
-            }
+            // add as new webmention
+            return Commentions::add($page, $finaldata);
         }
 
         // return error for any other HTTP codes

--- a/classes/Cron.php
+++ b/classes/Cron.php
@@ -3,6 +3,7 @@
 namespace sgkirby\Commentions;
 
 use Exception;
+use Kirby\Http\Remote;
 use Kirby\Http\Response;
 use Kirby\Http\Url;
 use Kirby\Toolkit\F;
@@ -135,137 +136,160 @@ class Cron
      */
     public static function parseWebmention($request)
     {
-        $source = $request['source'];
+        // find the Kirby page the target URL refers to
         $target = $request['target'];
+        $path = Url::path($target);
+        if ($path == '') {
+            // empty path means home page
+            $page = page('home');
+        } else {
+            // run the path through the router to determine real page
+            $page = page(kirby()->call(trim($path, '/')));
+        }
+        if (empty($page) || $page->isErrorPage()) {
+            return 'Could not resolve target URL to Kirby page';
+        }
 
-        // retrieve the source HTML
-        $sourcecontent = F::read($source);
+        // retrieve the source
+        $source = $request['source'];
+        // TODO: follow a limited amount of redirects
+        $remote = Remote::get($source);
 
-        // parse for microformats
-        $mf2   = \Mf2\parse($sourcecontent, $source);
+        // HTTP 410 = deletion
+        if ($remote->info()['http_code'] === 410 && $page->commentions('all')->filterBy('source', $source)->count() != 0) {
+            $updateid = $page->commentions('all')->filterBy('source', $source)->first()->uid()->toString();
+            return Commentions::update($page, $updateid, 'delete');
+        }
 
-        // process microformat data
-        if (isset($mf2['items'][0])) {
-            // parse the Mf2 array to a comment array
-            $result = \IndieWeb\comments\parse($mf2['items'][0], $target, 1000, 20);
+        // HTTP 200 = valid source
+        elseif ($remote->info()['http_code'] === 200) {
+            $sourcecontent = $remote->content();
+            if (empty($sourcecontent)) {
+                return 'Source content empty.';
+            }
 
-            // sometimes, the author name ends up in the url field
-            if (!empty($result['author']['url']) && !Str::isUrl($result['author']['url'])) {
-                if (empty($result['author']['name'])) {
-                    $result['author']['name'] = $result['author']['url'];
+            // parse for microformats
+            $mf2 = \Mf2\parse($sourcecontent, $source);
+
+            // process microformat data
+            if (isset($mf2['items'][0])) {
+                // parse the Mf2 array to a comment array
+                $result = \IndieWeb\comments\parse($mf2['items'][0], $target, 1000, 20);
+
+                // sometimes, the author name ends up in the url field
+                if (!empty($result['author']['url']) && !Str::isUrl($result['author']['url'])) {
+                    if (empty($result['author']['name'])) {
+                        $result['author']['name'] = $result['author']['url'];
+                    }
+                    $result['author']['url'] = false;
                 }
-                $result['author']['url'] = false;
-            }
 
-            // php-comments does not do rel=author
-            if (array_key_exists('url', $result['author']) && $result['author']['url'] === false && array_key_exists('rels', $mf2) && array_key_exists('author', $mf2['rels']) && array_key_exists(0, $mf2['rels']['author']) && is_string($mf2['rels']['author'][0])) {
-                $result['author']['url'] = $mf2['rels']['author'][0];
-            }
-
-            // if h-card is not embedded in h-entry, php-comments returns no author; check for h-card in mf2 output and fill in missing
-            $hcardfound = false;
-            foreach ($mf2['items'] as $mf2item) {
-                if ($mf2item['type'][0] == 'h-card') {
-                    $hcardfound = true;
-                    if (empty($result['author']['name'])  && !empty($mf2item['properties']['name'][0])) {
-                        $result['author']['name'] = $mf2item['properties']['name'][0];
-                    }
-                    if (empty($result['author']['photo']) && !empty($mf2item['properties']['photo'][0])) {
-                        $result['author']['photo'] = $mf2item['properties']['photo'][0];
-                    }
-                    if (empty($result['author']['url']) && !empty($mf2item['properties']['url'][0])) {
-                        $result['author']['url'] = $mf2item['properties']['url'][0];
-                    }
+                // php-comments does not do rel=author
+                if (array_key_exists('url', $result['author']) && $result['author']['url'] === false && array_key_exists('rels', $mf2) && array_key_exists('author', $mf2['rels']) && array_key_exists(0, $mf2['rels']['author']) && is_string($mf2['rels']['author'][0])) {
+                    $result['author']['url'] = $mf2['rels']['author'][0];
                 }
-            }
 
-            // if no h-card was found, try to use 'author' property of h-entry instead
-            if (!$hcardfound) {
+                // if h-card is not embedded in h-entry, php-comments returns no author; check for h-card in mf2 output and fill in missing
+                $hcardfound = false;
                 foreach ($mf2['items'] as $mf2item) {
-                    if ($mf2item['type'][0] == 'h-entry') {
-                        if (empty($result['author']['name'])  && !empty($mf2item['properties']['author'][0])) {
-                            $result['author']['name'] = $mf2item['properties']['author'][0];
+                    if ($mf2item['type'][0] == 'h-card') {
+                        $hcardfound = true;
+                        if (empty($result['author']['name'])  && !empty($mf2item['properties']['name'][0])) {
+                            $result['author']['name'] = $mf2item['properties']['name'][0];
+                        }
+                        if (empty($result['author']['photo']) && !empty($mf2item['properties']['photo'][0])) {
+                            $result['author']['photo'] = $mf2item['properties']['photo'][0];
+                        }
+                        if (empty($result['author']['url']) && !empty($mf2item['properties']['url'][0])) {
+                            $result['author']['url'] = $mf2item['properties']['url'][0];
                         }
                     }
                 }
-            }
 
-            // TODO: potentially implement author discovery from rel-author or author-page URLs; https://indieweb.org/authorship-spec
-
-            // do not keep author avatar URL unless activated in config option
-            if (isset($result['author']['photo']) && (bool)option('sgkirby.commentions.avatarurls')) {
-                $result['author']['photo'] = false;
-            }
-
-            // timestamp the webmention
-            if (!empty($result['published'])) {
-                // use date of source, if available
-                if (is_numeric($result['published'])) {
-                    $result['timestamp'] = $result['published'];
-                } else {
-                    $result['timestamp'] = strtotime($result['published']);
-                }
-            } else {
-                // otherwise use date the request received
-                $result['timestamp'] = $request['timestamp'];
-            }
-        }
-
-        // neither microformats nor backlink = no processing possible
-        elseif (! Str::contains($sourcecontent, $target)) {
-            return 'Could not verify link to target.';
-        }
-
-        // case: no microformats, but links back to target URL
-        else {
-            $result['timestamp'] = time();
-        }
-
-        // find the Kirby page the target URL refers to
-        $path = Url::path($target);
-        if ($path == '') {
-            $page = page('home');
-        } else {
-            $page = page(kirby()->call(trim($path, '/')));
-        }
-
-        if (!empty($page) && !$page->isErrorPage()) {
-            // if there is no link to this site in the source...
-            if (! Str::contains($sourcecontent, $target)) {
-                $found = false;
-
-                if (isset($mf2['items'][0])) {
-                    // ...maybe they instead linked to a syndicated copy?
-                    if ($page->syndication()->isNotEmpty()) {
-                        foreach ($page->syndication()->split() as $syndication) {
-                            if (Str::contains($sourcecontent, $syndication)) {
-                                $result = \IndieWeb\comments\parse($data['items'][0], $syndication);
-                                $found = true;
-                                break;
+                // if no h-card was found, try to use 'author' property of h-entry instead
+                if (!$hcardfound) {
+                    foreach ($mf2['items'] as $mf2item) {
+                        if ($mf2item['type'][0] == 'h-entry') {
+                            if (empty($result['author']['name'])  && !empty($mf2item['properties']['author'][0])) {
+                                $result['author']['name'] = $mf2item['properties']['author'][0];
                             }
                         }
                     }
                 }
 
-                // if no backlink can be found, just give up
-                if (!$found) {
-                    return 'Could not verify link to target.';
+                // TODO: potentially implement author discovery from rel-author or author-page URLs; https://indieweb.org/authorship-spec
+
+                // do not keep author avatar URL unless activated in config option
+                if (isset($result['author']['photo']) && (bool)option('sgkirby.commentions.avatarurls')) {
+                    $result['author']['photo'] = false;
+                }
+
+                // timestamp the webmention
+                if (!empty($result['published'])) {
+                    // use date of source, if available
+                    if (is_numeric($result['published'])) {
+                        $result['timestamp'] = $result['published'];
+                    } else {
+                        $result['timestamp'] = strtotime($result['published']);
+                    }
+                } else {
+                    // otherwise use date the request received
+                    $result['timestamp'] = $request['timestamp'];
+                }
+
+                // if there is no apparent link to this site in the source...
+                if (Str::contains($sourcecontent, $target)) {
+                    $linkfound = true;
+                } else {
+                    $linkfound = false;
+
+                    if (isset($mf2['items'][0])) {
+                        // ...maybe they instead linked to a syndicated copy?
+                        if ($page->syndication()->isNotEmpty()) {
+                            foreach ($page->syndication()->split() as $syndication) {
+                                if (Str::contains($sourcecontent, $syndication)) {
+                                    $result = \IndieWeb\comments\parse($data['items'][0], $syndication);
+                                    $linkfound = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // case: no microformats, but links back to target URL
+            elseif (Str::contains($sourcecontent, $target)) {
+                $result['timestamp'] = time();
+                $linkfound = true;
+            }
+
+            // neither microformats nor backlink, but could still be a deletion
+            else {
+                $linkfound = false;
+            }
+
+            // if source does not contain link to target, it's either deletion or invalid request
+            if (!$linkfound) {
+                if ($page->commentions('all')->filterBy('source', $source)->count() != 0) {
+                    $updateid = $page->commentions('all')->filterBy('source', $source)->first()->uid()->toString();
+                    return Commentions::update($page, $updateid, 'delete');
+                } else {
+                    return 'Source does not contain link to target.';
                 }
             }
 
             // set comment type, if not given or deprecated 'mention' given
-            if (!isset($result['type']) || $result['type'] == '' || $result['type'] == 'mention') {
+            if (empty($result['type']) || $result['type'] == 'mention') {
                 $result['type'] = 'webmention';
             }
 
             // create the commention data
             $finaldata = [
-                'status' => Commentions::defaultstatus($result['type']),
                 'name' => $result['author']['name'] ?? false,
                 'website' => $result['author']['url'] ?? false,
                 'avatar' => $result['author']['photo'] ?? false,
                 'text' => $result['text'],
-                'timestamp' => date(date('Y-m-d H:i'), $result['timestamp']),
                 'source' => $source,
                 'type' => $result['type'],
                 'language' => Commentions::determineLanguage($page, $path),
@@ -274,17 +298,18 @@ class Cron
             if ($page->commentions('all')->filterBy('source', $source)->count() != 0) {
                 // if webmention with this source url exists, this is an update
                 $updateid = $page->commentions('all')->filterBy('source', $source)->first()->uid()->toString();
-                // keep existing timestamp and status
-                unset($finaldata['timestamp']);
-                unset($finaldata['status']);
-                // update the existing webmention
                 return Commentions::update($page, $updateid, $finaldata);
             } else {
                 // add as new webmention
+                $finaldata['timestamp'] = date('Y-m-d H:i', $result['timestamp']);
+                $finaldata['status'] = Commentions::defaultstatus($result['type']);
                 return Commentions::add($page, $finaldata);
             }
-        } else {
-            return 'Could not resolve target URL to Kirby page';
+        }
+
+        // return error for any other HTTP codes
+        else {
+            return 'HTTP return code is neither 200 nor 410.';
         }
     }
 }

--- a/classes/Cron.php
+++ b/classes/Cron.php
@@ -136,8 +136,9 @@ class Cron
      */
     public static function parseWebmention($request)
     {
-        // find the Kirby page the target URL refers to
         $target = $request['target'];
+
+        // find the Kirby page the target URL refers to
         $path = Url::path($target);
         if ($path == '') {
             // empty path means home page
@@ -146,7 +147,7 @@ class Cron
             // run the path through the router to determine real page
             $page = page(kirby()->call(trim($path, '/')));
         }
-        if (empty($page) || $page->isErrorPage()) {
+        if (empty($page)) {
             return 'Could not resolve target URL to Kirby page';
         }
 

--- a/classes/Cron.php
+++ b/classes/Cron.php
@@ -73,7 +73,7 @@ class Cron
             foreach (Storage::read($page, 'webmentionqueue') as $queueitem) {
 
                 // skip requests already marked as failed or source-target pairs pinged during this cron run
-                if (!isset($queueitem['failed']) && !in_array(sha1($source . $target), $processedpairs)) {
+                if (!isset($queueitem['failed']) && !in_array($source . $target, $processedpairs)) {
 
                     // create/update the lockfile, as this is where actual DoS harm can be done
                     F::write($lockfile, '');
@@ -114,8 +114,8 @@ class Cron
                         throw new Exception('Problem processing queue item.');
                     }
 
-                    // add the sha1 hash of this source-target pair to eliminate duplicates during this run
-                    $processedpairs[] = sha1($source . $target);
+                    // add the source-target pair to eliminate duplicates during this run
+                    $processedpairs[] = $source . $target;
                 }
             }
         }

--- a/classes/Storage.php
+++ b/classes/Storage.php
@@ -110,12 +110,6 @@ class Storage
      */
     public static function update($page, $uid, $data = [], $filename)
     {
-        // clean up the data if it is an array (skip for string, which would be a command like 'delete')
-        if ($filename === 'commentions' && is_array($data) && !empty($data)) {
-            // sanitize data array, but keep the uid
-            $data = Commentions::sanitize($data, true);
-        }
-
         // loop through array of all comments
         $output = [];
         foreach (static::read($page, $filename) as $entry) {

--- a/index.css
+++ b/index.css
@@ -6,5 +6,6 @@
 			.k-section-name-commentions .k-list-item-commention-approved .k-list-item-image .k-icon svg { color:#a7bd68; }
 			.k-section-name-commentions .k-list-item-commention-unapproved .k-list-item-image .k-icon svg { color:#d16464; }
 			.k-section-name-commentions .k-list-item-commention-pending .k-list-item-image .k-icon svg { color:#d16464; }
+			.k-section-name-commentions .k-list-item-commention-update .k-list-item-image .k-icon svg { color:#d16464; }
 			.k-section-name-commentions .k-list-item-text { white-space:pre-line; }
 				.k-section-name-commentions .k-list-item-text small { opacity:0; }

--- a/sections/commentions.php
+++ b/sections/commentions.php
@@ -80,6 +80,9 @@ return [
                 $text = isset($data['text']) ? htmlspecialchars($data['text']) : '';
                 $name = isset($data['name']) ? htmlspecialchars($data['name']) : t('commentions.name.anonymous');
                 $meta = $data['type'];
+                if ($data['status'] === 'update') {
+                    $meta .= ' update';
+                }
 
                 // avoid returning empty array entries when no commentions exist
                 if (!empty($meta)) {
@@ -106,6 +109,14 @@ return [
                     } elseif ($data['status'] == 'unapproved') {
                         $class = 'k-list-item-commention-unapproved';
                         $icon = [ 'type' => 'protected', 'back' => 'transparent' ];
+                        $options[] = [
+                            'icon' => 'check',
+                            'text' => t('commentions.section.option.approve'),
+                            'click' => 'approve-' . $data['uid'] . '|' . $data['pageid']
+                        ];
+                    } elseif ($data['status'] == 'update') {
+                        $class = 'k-list-item-commention-update';
+                        $icon = [ 'type' => 'refresh', 'back' => 'transparent' ];
                         $options[] = [
                             'icon' => 'check',
                             'text' => t('commentions.section.option.approve'),


### PR DESCRIPTION
This might still require some fine tuning later (e.g. consideration that this way somebody could first get a "harmless" webmention approved and then send an update with some offensive text content), but at least the mechanism seems to work.

This PR does two things: it detects if the same source-target pair is queued several times (e.g. because somebody submitted it a few times in a short time) and it treats webmentions from the same source URL as an update when processing it.

Re: #41 