### PR TITLE
Allow per template

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,32 @@ The plugin maintains two log files at `site/logs/commentions`.
 
 The plugin can be configured with optional settings in your `site/config/config.php`.
 
+### Limit by template
+
+By default, the Commentions plugin accepts incoming comments and webmentions for all content.
+
+To limit the pages accepting comment submissions (separate setting for comments and webmentions), add arrays of template names allowing for incoming comments to your config:
+
+```php
+'sgkirby.commentions.templatesWithComments' => ['note', 'article'],
+'sgkirby.commentions.templatesWithWebmentions' => ['note'],
+```
+
+To disable a type of comments entirely, provide an empty array. For example, to allow comments on all pages with template `note` but disable webmentions entirely:
+
+```php
+'sgkirby.commentions.templatesWithComments' => ['note'],
+'sgkirby.commentions.templatesWithWebmentions' => [],
+```
+
+To limit comments to template `note` but allow webmentions across the entire website, omit the `'sgkirby.commentions.templatesWithWebmentions'` setting:
+
+```php
+'sgkirby.commentions.templatesWithComments' => ['note'],
+```
+
+_NB. This only affects incoming comments and/or webmentions; existing content and its display is not affected by this setting._
+
 ### Default status
 
 By default, all new comments and webmentions are set to status 'pending', i.e. awaiting confirmation by the admin. To change this global default, add this setting to your config:

--- a/classes/Commentions.php
+++ b/classes/Commentions.php
@@ -44,6 +44,33 @@ class Commentions
     }
 
     /**
+     * Checks if a page accepts comments/webmentions based on its template
+     *
+     * @param \Kirby\Cms\Page $page The page object
+     * @return bool
+     */
+    public static function accepted($page, string $type)
+    {
+        if (!in_array($type, ['webmentions', 'comments'])) {
+            return false;
+        }
+
+        $allowlist = option('sgkirby.commentions.templatesWith' . ucfirst($type));
+
+        // if no allowlist is set, comments and webmentions are allowed on all pages
+        if (!is_array($allowlist)) {
+            return true;
+        }
+
+        // if applicable template is in allowlist, return true
+        if (in_array($page->intendedTemplate(), $allowlist)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Generates random comment UID
      *
      * @return string A random alpahnumeric string (10 characters)

--- a/classes/Cron.php
+++ b/classes/Cron.php
@@ -90,7 +90,7 @@ class Cron
                     $pingeddomains[$sourcedomain] = time();
 
                     // parse the request
-                    if ($result = static::parseWebmention($queueitem)) {
+                    if ($result = static::parseWebmention($page, $queueitem)) {
 
                         // if parsing was successful, $result is the array with the saved data
                         if (is_array($result)) {
@@ -143,22 +143,9 @@ class Cron
      * @return array|string - Array: The complete comment data (incl. UID) as returned by the Storage class after saving
      *                      - String: Human-readable error message in case of failure
      */
-    public static function parseWebmention($request)
+    public static function parseWebmention($page, $request)
     {
         $target = $request['target'];
-
-        // find the Kirby page the target URL refers to
-        $path = Url::path($target);
-        if ($path == '') {
-            // empty path means home page
-            $page = page('home');
-        } else {
-            // run the path through the router to determine real page
-            $page = page(kirby()->call(trim($path, '/')));
-        }
-        if (empty($page)) {
-            return 'Could not resolve target URL to Kirby page';
-        }
 
         // retrieve the source and use the final URL (after possible redirects) for processing
         $remote = Remote::get($request['source']);
@@ -301,7 +288,7 @@ class Cron
                 'text'      => $result['text'],
                 'source'    => $source,
                 'type'      => $result['type'],
-                'language'  => Commentions::determineLanguage($page, $path),
+                'language'  => Commentions::determineLanguage($page, Url::path($target)),
                 'timestamp' => date('Y-m-d H:i', $result['timestamp']),
                 'status'    => Commentions::defaultstatus($result['type']),
             ];

--- a/classes/Endpoint.php
+++ b/classes/Endpoint.php
@@ -91,7 +91,7 @@ class Endpoint
         if ($path == '') {
             $page = page(site()->homePageId());
         } else {
-            $page = page(kirby()->call(trim($path, '/')));
+            $page = page(kirby()->router()->call($path));
         }
 
         // if url does not resolve to valid page, attach to homepage instead

--- a/sections/commentions.php
+++ b/sections/commentions.php
@@ -51,13 +51,15 @@ return [
 
             $errors = [];
 
-            $logfile = kirby()->root('site') . DS . 'logs' . DS . 'commentions' . DS . 'lastcron.log';
-            if (!F::exists($logfile) || F::modified($logfile) < (time() - 86400)) {
-                $errors[] = [
-                    'id'      => 'cronjob-alert',
-                    'message' => t('commentions.section.error.cronjob-alert'),
-                    'theme'   => 'negative',
-                ];
+            if (Commentions::accepted($this->model(), 'webmentions')) {
+                $logfile = kirby()->root('site') . DS . 'logs' . DS . 'commentions' . DS . 'lastcron.log';
+                if (!F::exists($logfile) || F::modified($logfile) < (time() - 86400)) {
+                    $errors[] = [
+                        'id'      => 'cronjob-alert',
+                        'message' => t('commentions.section.error.cronjob-alert'),
+                        'theme'   => 'negative',
+                    ];
+                }
             }
 
             if (is_dir(kirby()->root() . DS . 'content' . DS . '.commentions') === true) {

--- a/snippets/commentions-form.php
+++ b/snippets/commentions-form.php
@@ -57,6 +57,8 @@
 
     </form>
 
+    <?php if (\sgkirby\Commentions\Commentions::accepted($page, 'webmentions')) : ?>
+
     <?php if (option('sgkirby.commentions.expand')) : ?>
 
     <h3 class="expander" id="commentions-form-webmention">
@@ -85,5 +87,7 @@
       <input type="submit" name="submit" value="Send webmention">
 
     </form>
+
+    <?php endif; ?>
 
   </div>


### PR DESCRIPTION
Logic:
- by default, the plugin is active for all templates and accepts both comments and webmentions for those (I believe this is the most sensible approach, as this allows using the plugin without any settings; since the default status is "pending", no harm done)
- two optional config arrays (one for comments, one for webmentions) - if the array exists, the respective type is accepted only for those pages whose template name is in the array
- this implicitly makes it possible to disable one or both types for all pages by setting an empty array
- only affects submission/creation of incoming stuff (incl. hiding the form) but does not affect commentions existing already (i.e. the list helper still works even on pages with a template not on the allowlist)

see https://github.com/sebastiangreger/kirby3-commentions/blob/allow-per-template/README.md#limit-by-template