### PR TITLE
Remove <strong> tag from formatted source

### DIFF
--- a/lib/Commention.php
+++ b/lib/Commention.php
@@ -79,7 +79,7 @@ class Commention extends StructureObject
         if ($this->website()->isNotEmpty()) {
             $author = '<a href="' . $this->website() . '" rel="noopener noreferrer nofollow">' . $author . '</a>';
         } else {
-            $author = "<strong>{$author}</strong>";
+            $author = "<span>{$author}</span>";
         }
 
         // Format domain of source URL


### PR DESCRIPTION
This is a tiny one, but just putting into review before merging to check if you think this is ok, @fabianmichael:

The currently realized that the hard-coded `<strong>` tags in the sourceFormatted() function leads to an odd default rendering where the string "Anonymous" is highlighted as opposed to the real name of a commenter:

![Screenshot from 2021-05-12 14-24-22](https://user-images.githubusercontent.com/6355217/117975090-997e7080-b32e-11eb-9df8-3aa4318322a8.png)

Changing this to a `<span>` tag still enables styling with CSS, but removes the semantic highlight. Should not cause too much of a headache along with the other breaking changes, right?