### PR TITLE
Fix plugin breaking in 3.7

### DIFF
--- a/lib/Commention.php
+++ b/lib/Commention.php
@@ -121,7 +121,16 @@ class Commention extends StructureObject
             'domain' => $domain,
         ];
 
-        return Str::template($translation, $replace, ['fallback' => null, 'start' => '{', 'end' => '}']);
+        // Use single brackets (instead of double) to match the behavior
+        // of Kirby’s `tt()` helper function.
+        if (version_compare(\Kirby\Cms\App::version(), '3.6') >= 0) {
+            return Str::template($translation, $replace, ['fallback' => null, 'start' => '{', 'end' => '}']);
+        }
+        // keep backward-compatible with core <3.6
+        else {
+            return Str::template($translation, $replace, null, '{', '}');
+        }
+
     }
 
     /**

--- a/lib/Commention.php
+++ b/lib/Commention.php
@@ -121,16 +121,7 @@ class Commention extends StructureObject
             'domain' => $domain,
         ];
 
-        // Use single brackets (instead of double) to match the behavior
-        // of Kirby’s `tt()` helper function.
-        if (substr(\Kirby\Cms\App::version(), 0, 3) === '3.6') {
-            return Str::template($translation, $replace, ['fallback' => null, 'start' => '{', 'end' => '}']);
-        }
-        /* TODO: only keep array version once K3.6 is out */
-        else {
-            return Str::template($translation, $replace, null, '{', '}');
-        }
-
+        return Str::template($translation, $replace, ['fallback' => null, 'start' => '{', 'end' => '}']);
     }
 
     /**


### PR DESCRIPTION
I removed the legacy code fix for Kirby versions prior to 3.6. If you prefer to keep it, we could also go with [`version_compare()`](https://www.php.net/version_compare) instead. But I honestly think, that only supporting recent Kirby versions would make things a lot easier.