### PR TITLE
Fixes for kirby37

### DIFF
--- a/languages/de.php
+++ b/languages/de.php
@@ -58,6 +58,7 @@ $translations = [
     'snippet.list.replies'              => '{ author } antwortete auf { link }',
     'snippet.list.dateFormat.date'      => 'd.m.Y H:i \U\h\r',
     'snippet.list.dateFormat.strftime'  => '%d.%m.%Y %H:%M Uhr',
+    'snippet.list.dateFormat.intl'      => "dd.MM.yyyy HH:mm 'Uhr'",
 
 
     // feedback

--- a/languages/en.php
+++ b/languages/en.php
@@ -58,6 +58,7 @@ $translations = [
     'snippet.list.replies'             => '{ author } replied at { link }',
     'snippet.list.dateFormat.date'     => 'Y-m-d H:i',
     'snippet.list.dateFormat.strftime' => '%Y-%m-%d %H:%M',
+    'snippet.list.dateFormat.intl'     => 'yyyy-MM-dd HH:mm',
 
 
     // feedback

--- a/languages/fr.php
+++ b/languages/fr.php
@@ -58,6 +58,7 @@ $translations = [
     'snippet.list.replies'             => '{ author } a répondu sur { link }',
     'snippet.list.dateFormat.date'     => 'd-m-Y H:i',
     'snippet.list.dateFormat.strftime' => '%d-%m-%Y %H:%M',
+    'snippet.list.dateFormat.intl'     => 'yyyy-MM-dd HH:mm',
 
 
     // feedback

--- a/lib/Commention.php
+++ b/lib/Commention.php
@@ -193,10 +193,7 @@ class Commention extends StructureObject
     {
         // Get the right date format from translations, based on the
         // date handler set for Kirby.
-        $format = option('date.handler') === 'strftime'
-            ? t('commentions.snippet.list.dateFormat.strftime')
-            : t('commentions.snippet.list.dateFormat.date');
-
+        $format = t('commentions.snippet.list.dateFormat.' . option('date.handler', 'date'));
         return $this->timestamp()->toDate($format);
     }
 }

--- a/lib/Commention.php
+++ b/lib/Commention.php
@@ -193,7 +193,19 @@ class Commention extends StructureObject
     {
         // Get the right date format from translations, based on the
         // date handler set for Kirby.
-        $format = t('commentions.snippet.list.dateFormat.' . option('date.handler', 'date'));
+        switch (option('date.handler', 'date')) {
+            case "intl":
+                $format = t('commentions.snippet.list.dateFormat.intl');
+                break;
+            case "strftime":
+                $format = t('commentions.snippet.list.dateFormat.strftime');
+                break;
+            case "date":
+            default:
+                $format = t('commentions.snippet.list.dateFormat.date');
+                break;
+        }
+
         return $this->timestamp()->toDate($format);
     }
 }

--- a/lib/Cron.php
+++ b/lib/Cron.php
@@ -6,7 +6,6 @@ use Exception;
 use Kirby\Http\Remote;
 use Kirby\Http\Response;
 use Kirby\Http\Url;
-use Kirby\Toolkit\Dir;
 use Kirby\Toolkit\F;
 use Kirby\Toolkit\Str;
 

--- a/lib/Structure.php
+++ b/lib/Structure.php
@@ -32,7 +32,7 @@ class Structure extends BaseStructure
      * @param string $id
      * @param array|Commention $props
      */
-    public function __set(string $id, $props)
+    public function __set(string $id, $props): void
     {
         if (is_a($props, 'sgkirby\Commentions\Commention') === true) {
             $object = $props;
@@ -53,6 +53,6 @@ class Structure extends BaseStructure
             ]);
         }
 
-        return parent::__set($object->id(), $object);
+        parent::__set($object->id(), $object);
     }
 }


### PR DESCRIPTION
Hi @sebastiangreger, just made a tiny amount of adjustments to make it work with Kirbsy 3.7. Mid-terms, we should really consider dropping support for Kirby before 3.6, because it will add too much bloat to the code (e.g. references to the old `Kirby\Toolkit\F` class, which became `Kirby\Filesystem\F`).